### PR TITLE
fix: directLink in public link contexts

### DIFF
--- a/cernbox-integration/src/components/DirectLink.vue
+++ b/cernbox-integration/src/components/DirectLink.vue
@@ -23,7 +23,7 @@ import { defineComponent, unref } from 'vue'
 import { Resource, SpaceResource } from '@ownclouders/web-client'
 import { PropType } from 'vue'
 import { useClipboard } from '@vueuse/core'
-import { useAuthStore, useMessages, useRouter } from '@ownclouders/web-pkg'
+import { useMessages } from '@ownclouders/web-pkg'
 import { useGettext } from 'vue3-gettext'
 
 export default defineComponent({
@@ -32,17 +32,11 @@ export default defineComponent({
     resource: { type: Object as PropType<Resource>, required: true }
   },
   setup(props) {
-    const authStore = useAuthStore()
     const messageStore = useMessages()
 
-    const isPublicLinkContext = authStore.publicLinkContextReady
-
-    const router = useRouter()
     const { $gettext } = useGettext()
 
-    const directLink = !unref(isPublicLinkContext)
-      ? props.resource.privateLink
-      : props.resource.downloadURL
+    const directLink = props.resource.privateLink
 
     const { copy, isSupported: isClipboardCopySupported } = useClipboard({
       legacy: true,

--- a/cernbox-integration/src/components/PathDetails.vue
+++ b/cernbox-integration/src/components/PathDetails.vue
@@ -23,7 +23,7 @@
             name="checkbox-circle"
             class="_clipboard-success-animation"
           />
-          <oc-icon v-else key="oc-copy-to-clipboard-copy" name="clipboard" />
+          <oc-icon v-else key="oc-copy-to-clipboard-copy" name="file-copy" />
         </oc-button>
       </div>
     </td>
@@ -51,7 +51,7 @@
             name="checkbox-circle"
             class="_clipboard-success-animation"
           />
-          <oc-icon v-else key="oc-copy-to-clipboard-copy" name="clipboard" />
+          <oc-icon v-else key="oc-copy-to-clipboard-copy" name="file-copy" />
         </oc-button>
       </div>
     </td>
@@ -75,7 +75,7 @@
             name="checkbox-circle"
             class="_clipboard-success-animation"
           />
-          <oc-icon v-else key="oc-copy-to-clipboard-copy" name="clipboard" />
+          <oc-icon v-else key="oc-copy-to-clipboard-copy" name="file-copy" />
         </oc-button>
       </div>
     </td>

--- a/cernbox-integration/src/components/PathDetails.vue
+++ b/cernbox-integration/src/components/PathDetails.vue
@@ -88,7 +88,6 @@ import { PropType } from 'vue'
 import { useClipboard } from '@vueuse/core'
 import { isLocationTrashActive, useAuthStore, useRouter, useMessages } from '@ownclouders/web-pkg'
 import { useGettext } from 'vue3-gettext'
-import { urlJoin } from '@ownclouders/web-client'
 
 export default defineComponent({
   props: {
@@ -116,11 +115,7 @@ export default defineComponent({
       return isLocationTrashActive(router, 'files-trash-generic')
     })
 
-    const directLink = computed(() => {
-      return !unref(isPublicLinkContext)
-        ? props.resource.privateLink
-        : urlJoin(props.resource.downloadURL)
-    })
+    const directLink = computed(() => props.resource.privateLink)
 
     const copyEosPathToClipboard = () => {
       copy(unref(eosPath))


### PR DESCRIPTION
- there is no need to use the downloadURL, since the privateLink property is expected to always be there.
- icons updated to match WebDAV ones 